### PR TITLE
Update to use v5.7.0

### DIFF
--- a/5.7.0/Dockerfile
+++ b/5.7.0/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update \
 RUN apk add --no-cache bash=5.0.0-r0
 RUN apk add --no-cache curl=7.65.1-r0
 
-ADD https://github.com/concourse/concourse/releases/download/v5.4.1/fly-5.4.1-linux-amd64.tgz /tmp/fly.tgz
+ADD https://github.com/concourse/concourse/releases/download/v5.7.0/fly-5.7.0-linux-amd64.tgz /tmp/fly.tgz
 
 RUN tar zxvf /tmp/fly.tgz -C /usr/bin \
     && rm -f /tmp/fly.tgz \


### PR DESCRIPTION
Use 5.7.0 instead of version 5.4.7 to match concourse version used